### PR TITLE
fix(auth): redirect root to dashboard and fix nav flash for unauthent…

### DIFF
--- a/src/components/layouts/ConditionalLayout.test.tsx
+++ b/src/components/layouts/ConditionalLayout.test.tsx
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before importing the component
+// ---------------------------------------------------------------------------
+
+vi.mock('@/lib/auth-client', () => ({
+  useSession: vi.fn(() => ({
+    data: { user: { id: 'user-123', name: 'Test User', email: 'test@example.com' } },
+    isPending: false,
+    error: null,
+  })),
+}))
+
+vi.mock('@/components/shared/Sidebar', () => ({
+  default: () => React.createElement('div', { 'data-testid': 'sidebar' }),
+}))
+
+vi.mock('@/components/shared/BottomBar', () => ({
+  default: () => React.createElement('div', { 'data-testid': 'bottombar' }),
+}))
+
+// ---------------------------------------------------------------------------
+// Imports — after mocks
+// ---------------------------------------------------------------------------
+
+import ConditionalLayout from './ConditionalLayout'
+import { useSession } from '@/lib/auth-client'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function renderLayout(children = React.createElement('main', { 'data-testid': 'page-content' }, 'Page Content')) {
+  return render(React.createElement(ConditionalLayout, null, children))
+}
+
+type UseSessionReturn = {
+  data: { user: { id: string; name: string; email: string } } | null
+  isPending: boolean
+  error: null
+}
+
+function mockUseSession(overrides: Partial<UseSessionReturn>) {
+  vi.mocked(useSession).mockReturnValue({
+    data: { user: { id: 'user-123', name: 'Test User', email: 'test@example.com' } },
+    isPending: false,
+    error: null,
+    ...overrides,
+  } as ReturnType<typeof useSession>)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  // Default: authenticated, not pending
+  mockUseSession({})
+})
+
+describe('ConditionalLayout', () => {
+  // -------------------------------------------------------------------------
+  describe('authenticated state (session present, not pending)', () => {
+    it('renders the Sidebar', () => {
+      renderLayout()
+      expect(screen.getByTestId('sidebar')).toBeTruthy()
+    })
+
+    it('renders the BottomBar', () => {
+      renderLayout()
+      expect(screen.getByTestId('bottombar')).toBeTruthy()
+    })
+
+    it('renders children inside the content wrapper', () => {
+      renderLayout()
+      expect(screen.getByTestId('page-content')).toBeTruthy()
+      expect(screen.getByText('Page Content')).toBeTruthy()
+    })
+
+    it('wraps children in a flex-1 overflow-auto div', () => {
+      renderLayout()
+      const contentWrapper = screen.getByTestId('page-content').parentElement
+      expect(contentWrapper?.className).toContain('flex-1')
+      expect(contentWrapper?.className).toContain('overflow-auto')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  describe('loading state (isPending true — the flash fix)', () => {
+    beforeEach(() => {
+      mockUseSession({ data: null, isPending: true })
+    })
+
+    it('does NOT render the Sidebar while auth is pending', () => {
+      renderLayout()
+      expect(screen.queryByTestId('sidebar')).toBeNull()
+    })
+
+    it('does NOT render the BottomBar while auth is pending', () => {
+      renderLayout()
+      expect(screen.queryByTestId('bottombar')).toBeNull()
+    })
+
+    it('still renders children while auth is pending', () => {
+      renderLayout()
+      expect(screen.getByTestId('page-content')).toBeTruthy()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  describe('unauthenticated state (no session, not pending)', () => {
+    beforeEach(() => {
+      mockUseSession({ data: null, isPending: false })
+    })
+
+    it('does NOT render the Sidebar when there is no session', () => {
+      renderLayout()
+      expect(screen.queryByTestId('sidebar')).toBeNull()
+    })
+
+    it('does NOT render the BottomBar when there is no session', () => {
+      renderLayout()
+      expect(screen.queryByTestId('bottombar')).toBeNull()
+    })
+
+    it('still renders children when unauthenticated', () => {
+      renderLayout()
+      expect(screen.getByTestId('page-content')).toBeTruthy()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  describe('transition: loading -> authenticated', () => {
+    it('shows nav chrome only after isPending becomes false and session is present', () => {
+      // First render: loading
+      mockUseSession({ data: null, isPending: true })
+      const { rerender } = renderLayout()
+      expect(screen.queryByTestId('sidebar')).toBeNull()
+
+      // Second render: authenticated
+      mockUseSession({ data: { user: { id: 'user-123', name: 'Test User', email: 'test@example.com' } }, isPending: false })
+      rerender(
+        React.createElement(
+          ConditionalLayout,
+          null,
+          React.createElement('main', { 'data-testid': 'page-content' }, 'Page Content'),
+        ),
+      )
+      expect(screen.getByTestId('sidebar')).toBeTruthy()
+      expect(screen.getByTestId('bottombar')).toBeTruthy()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  describe('children rendering variety', () => {
+    it('renders multiple children when authenticated', () => {
+      vi.mocked(useSession).mockReturnValue({
+        data: { user: { id: 'user-123', name: 'Test User', email: 'test@example.com' } },
+        isPending: false,
+        error: null,
+      } as ReturnType<typeof useSession>)
+
+      render(
+        React.createElement(
+          ConditionalLayout,
+          null,
+          React.createElement('div', { 'data-testid': 'child-one' }),
+          React.createElement('div', { 'data-testid': 'child-two' }),
+        ),
+      )
+
+      expect(screen.getByTestId('child-one')).toBeTruthy()
+      expect(screen.getByTestId('child-two')).toBeTruthy()
+    })
+  })
+})

--- a/src/components/layouts/ConditionalLayout.tsx
+++ b/src/components/layouts/ConditionalLayout.tsx
@@ -8,7 +8,7 @@ import BottomBar from '@/components/shared/BottomBar'
 export default function ConditionalLayout({ children }: { children: React.ReactNode }) {
   const { data: session, isPending } = useSession()
 
-  if (!isPending && !session) {
+  if (isPending || !session) {
     return <>{children}</>
   }
 

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before importing the module under test
+// ---------------------------------------------------------------------------
+
+vi.mock('@better-fetch/fetch', () => ({
+  betterFetch: vi.fn(),
+}))
+
+// next/server stubs — we only need the subset used by middleware
+vi.mock('next/server', () => {
+  const redirect = vi.fn((url: URL) => ({
+    type: 'redirect',
+    url: url.toString(),
+  }))
+
+  const next = vi.fn(() => ({ type: 'next' }))
+
+  return {
+    NextRequest: vi.fn(),
+    NextResponse: { redirect, next },
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Imports — after mocks
+// ---------------------------------------------------------------------------
+
+import { betterFetch } from '@better-fetch/fetch'
+import { NextResponse } from 'next/server'
+import { middleware } from './middleware'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRequest(pathname: string, origin = 'http://localhost:3000') {
+  return {
+    nextUrl: {
+      origin,
+      pathname,
+    },
+    url: `${origin}${pathname}`,
+    headers: {
+      get: vi.fn(() => 'session-cookie=abc'),
+    },
+  } as unknown as import('next/server').NextRequest
+}
+
+function mockSession(session: unknown) {
+  vi.mocked(betterFetch).mockResolvedValue({ data: session, error: null })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+describe('middleware', () => {
+  // -------------------------------------------------------------------------
+  describe('authenticated user redirects', () => {
+    it('redirects authenticated user on "/" to /dashboard', async () => {
+      mockSession({ user: { id: 'user-123' } })
+      await middleware(makeRequest('/'))
+
+      expect(NextResponse.redirect).toHaveBeenCalledTimes(1)
+      const redirectArg = vi.mocked(NextResponse.redirect).mock.calls[0][0] as URL
+      expect(redirectArg.toString()).toContain('/dashboard')
+    })
+
+    it('redirects authenticated user on "/sign-in" to /dashboard', async () => {
+      mockSession({ user: { id: 'user-123' } })
+      await middleware(makeRequest('/sign-in'))
+
+      expect(NextResponse.redirect).toHaveBeenCalledTimes(1)
+      const redirectArg = vi.mocked(NextResponse.redirect).mock.calls[0][0] as URL
+      expect(redirectArg.toString()).toContain('/dashboard')
+    })
+
+    it('redirects authenticated user on "/sign-up" to /dashboard', async () => {
+      mockSession({ user: { id: 'user-123' } })
+      await middleware(makeRequest('/sign-up'))
+
+      expect(NextResponse.redirect).toHaveBeenCalledTimes(1)
+      const redirectArg = vi.mocked(NextResponse.redirect).mock.calls[0][0] as URL
+      expect(redirectArg.toString()).toContain('/dashboard')
+    })
+
+    it('does NOT redirect authenticated user on a protected page like /dashboard', async () => {
+      mockSession({ user: { id: 'user-123' } })
+      await middleware(makeRequest('/dashboard'))
+
+      expect(NextResponse.redirect).not.toHaveBeenCalled()
+      expect(NextResponse.next).toHaveBeenCalledTimes(1)
+    })
+
+    it('does NOT redirect authenticated user on /transactions', async () => {
+      mockSession({ user: { id: 'user-123' } })
+      await middleware(makeRequest('/transactions'))
+
+      expect(NextResponse.redirect).not.toHaveBeenCalled()
+      expect(NextResponse.next).toHaveBeenCalledTimes(1)
+    })
+
+    it('does NOT redirect authenticated user on /accounts', async () => {
+      mockSession({ user: { id: 'user-123' } })
+      await middleware(makeRequest('/accounts'))
+
+      expect(NextResponse.redirect).not.toHaveBeenCalled()
+      expect(NextResponse.next).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  describe('unauthenticated user redirects', () => {
+    it('redirects unauthenticated user on "/" to /sign-in', async () => {
+      mockSession(null)
+      await middleware(makeRequest('/'))
+
+      expect(NextResponse.redirect).toHaveBeenCalledTimes(1)
+      const redirectArg = vi.mocked(NextResponse.redirect).mock.calls[0][0] as URL
+      expect(redirectArg.toString()).toContain('/sign-in')
+    })
+
+    it('redirects unauthenticated user on /dashboard to /sign-in', async () => {
+      mockSession(null)
+      await middleware(makeRequest('/dashboard'))
+
+      expect(NextResponse.redirect).toHaveBeenCalledTimes(1)
+      const redirectArg = vi.mocked(NextResponse.redirect).mock.calls[0][0] as URL
+      expect(redirectArg.toString()).toContain('/sign-in')
+    })
+
+    it('redirects unauthenticated user on /transactions to /sign-in', async () => {
+      mockSession(null)
+      await middleware(makeRequest('/transactions'))
+
+      expect(NextResponse.redirect).toHaveBeenCalledTimes(1)
+      const redirectArg = vi.mocked(NextResponse.redirect).mock.calls[0][0] as URL
+      expect(redirectArg.toString()).toContain('/sign-in')
+    })
+
+    it('allows unauthenticated user to reach /sign-in without redirect', async () => {
+      mockSession(null)
+      await middleware(makeRequest('/sign-in'))
+
+      expect(NextResponse.redirect).not.toHaveBeenCalled()
+      expect(NextResponse.next).toHaveBeenCalledTimes(1)
+    })
+
+    it('allows unauthenticated user to reach /sign-up without redirect', async () => {
+      mockSession(null)
+      await middleware(makeRequest('/sign-up'))
+
+      expect(NextResponse.redirect).not.toHaveBeenCalled()
+      expect(NextResponse.next).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  describe('betterFetch call', () => {
+    it('calls betterFetch with /api/auth/get-session and forwards cookies', async () => {
+      mockSession(null)
+      const req = makeRequest('/sign-in')
+      await middleware(req)
+
+      expect(betterFetch).toHaveBeenCalledWith(
+        '/api/auth/get-session',
+        expect.objectContaining({
+          baseURL: 'http://localhost:3000',
+          headers: expect.objectContaining({
+            cookie: 'session-cookie=abc',
+          }),
+        }),
+      )
+    })
+
+    it('falls back to empty string when the cookie header is absent', async () => {
+      mockSession(null)
+      const req = makeRequest('/sign-in')
+      vi.mocked(req.headers.get).mockReturnValue(null)
+      await middleware(req)
+
+      expect(betterFetch).toHaveBeenCalledWith(
+        '/api/auth/get-session',
+        expect.objectContaining({
+          headers: expect.objectContaining({ cookie: '' }),
+        }),
+      )
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  describe('config export', () => {
+    it('exports a matcher that excludes _next/static paths', async () => {
+      const { config } = await import('./middleware')
+      expect(config.matcher).toBeDefined()
+      expect(Array.isArray(config.matcher)).toBe(true)
+      // The pattern should exclude _next, api, and favicon.ico
+      const pattern = config.matcher[0]
+      expect(pattern).toContain('_next/static')
+      expect(pattern).toContain('favicon.ico')
+    })
+  })
+})

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -14,8 +14,8 @@ export async function middleware(request: NextRequest) {
 
 	const { pathname } = request.nextUrl;
 
-	// If user has session and tries to access auth pages, redirect to dashboard
-	if (session && (pathname === '/sign-in' || pathname === '/sign-up')) {
+	// If user has session and is on root or auth pages, redirect to dashboard
+	if (session && (pathname === '/' || pathname === '/sign-in' || pathname === '/sign-up')) {
 		return NextResponse.redirect(new URL("/dashboard", request.url));
 	}
  


### PR DESCRIPTION
…icated users

Middleware now redirects authenticated users from / to /dashboard so the root route never renders. ConditionalLayout hides sidebar/bottombar while the session is loading (isPending), eliminating the brief nav flash for unauthenticated users.