### PR TITLE
perf(api): defer statement recalculation and parallelize queries

### DIFF
--- a/src/app/api/expense-transactions/[id]/route.test.ts
+++ b/src/app/api/expense-transactions/[id]/route.test.ts
@@ -6,6 +6,14 @@ vi.mock('next/headers', () => ({
   headers: vi.fn(() => Promise.resolve(new Headers())),
 }));
 
+vi.mock('next/server', async (importActual) => {
+  const mod = await importActual<typeof import('next/server')>();
+  return {
+    ...mod,
+    after: (cb: () => unknown) => { void cb(); },
+  };
+});
+
 vi.mock('@/lib/auth', () => ({
   auth: {
     api: {

--- a/src/app/api/expense-transactions/[id]/route.ts
+++ b/src/app/api/expense-transactions/[id]/route.ts
@@ -2,6 +2,7 @@ import { auth } from "@/lib/auth";
 import { db } from "@/lib/prisma";
 import { onExpenseTransactionChange } from "@/lib/statement-recalculator";
 import { headers } from "next/headers";
+import { after } from "next/server";
 import { NextRequest, NextResponse } from "next/server";
 import { PrismaPromise } from "@prisma/client";
 import { z } from "zod";
@@ -296,8 +297,19 @@ export async function PATCH(
     const results = await db.$transaction(operations);
     const result = results[results.length - 1] as { accountId: string; date: Date };
 
-    await onExpenseTransactionChange(existingExpense.accountId, existingExpense.date);
-    await onExpenseTransactionChange(result.accountId, result.date);
+    const oldAccountId = existingExpense.accountId;
+    const oldDate = existingExpense.date;
+    const newAccountId = result.accountId;
+    const newDate = result.date;
+
+    after(async () => {
+      try {
+        await onExpenseTransactionChange(oldAccountId, oldDate);
+        await onExpenseTransactionChange(newAccountId, newDate);
+      } catch (err) {
+        console.error('Error in deferred onExpenseTransactionChange (PATCH expense):', err);
+      }
+    });
 
     return NextResponse.json(result, { status: 200 });
   } catch (error) {
@@ -389,7 +401,16 @@ export async function DELETE(
 
     await db.$transaction(operations);
 
-    await onExpenseTransactionChange(existingExpense.accountId, existingExpense.date);
+    const deletedAccountId = existingExpense.accountId;
+    const deletedDate = existingExpense.date;
+
+    after(async () => {
+      try {
+        await onExpenseTransactionChange(deletedAccountId, deletedDate);
+      } catch (err) {
+        console.error('Error in deferred onExpenseTransactionChange (DELETE expense):', err);
+      }
+    });
 
     return NextResponse.json(
       { message: 'Expense deleted successfully', deleted: true },

--- a/src/app/api/expense-transactions/route.test.ts
+++ b/src/app/api/expense-transactions/route.test.ts
@@ -6,6 +6,14 @@ vi.mock('next/headers', () => ({
   headers: vi.fn(() => Promise.resolve(new Headers())),
 }));
 
+vi.mock('next/server', async (importActual) => {
+  const mod = await importActual<typeof import('next/server')>();
+  return {
+    ...mod,
+    after: (cb: () => unknown) => { void cb(); },
+  };
+});
+
 vi.mock('@/lib/auth', () => ({
   auth: {
     api: {

--- a/src/app/api/expense-transactions/route.ts
+++ b/src/app/api/expense-transactions/route.ts
@@ -1,5 +1,6 @@
 import { auth } from "@/lib/auth";
 import { headers } from "next/headers";
+import { after } from "next/server";
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/prisma";
 import { INSTALLMENT_STATUS } from "./[id]/route";
@@ -134,30 +135,30 @@ export async function GET(request: NextRequest) {
       whereClause.accountId = accountId;
     }
 
-    const total = await db.expenseTransaction.count({
-      where: whereClause,
-    });
-
     let effectiveTake = takeNumber;
     if (search && search.trim().length > 0) {
       effectiveTake = 100;
     }
 
-    // Get transactions with optional pagination
-    const expenseTransactions = await db.expenseTransaction.findMany({
-      where: whereClause,
-      include: {
-        account: true,
-        expenseType: true,
-        expenseSubcategory: true,
-        tags: true,
-      },
-      orderBy: {
-        date: 'desc',
-      },
-      ...(skipNumber !== undefined && { skip: skipNumber }),
-      ...(effectiveTake !== undefined && { take: effectiveTake }),
-    });
+    const [total, expenseTransactions] = await Promise.all([
+      db.expenseTransaction.count({
+        where: whereClause,
+      }),
+      db.expenseTransaction.findMany({
+        where: whereClause,
+        include: {
+          account: true,
+          expenseType: true,
+          expenseSubcategory: true,
+          tags: true,
+        },
+        orderBy: {
+          date: 'desc',
+        },
+        ...(skipNumber !== undefined && { skip: skipNumber }),
+        ...(effectiveTake !== undefined && { take: effectiveTake }),
+      }),
+    ]);
 
     // Calculate hasMore
     const currentCount = (skipNumber || 0) + expenseTransactions.length;
@@ -370,8 +371,17 @@ export async function POST(request: NextRequest) {
 
     const results = await db.$transaction(operations);
     const result = results[0] as { accountId: string; date: Date };
+    // The financialAccount.update result (when present) carries accountType
+    const accountResult = results[1] as { accountType?: string } | undefined;
+    const accountType = accountResult?.accountType;
 
-    await onExpenseTransactionChange(result.accountId, result.date);
+    after(async () => {
+      try {
+        await onExpenseTransactionChange(result.accountId, result.date, undefined, accountType);
+      } catch (err) {
+        console.error('Error in deferred onExpenseTransactionChange (POST expense):', err);
+      }
+    });
 
     return NextResponse.json(result, { status: 201 });
   } catch (error) {

--- a/src/app/api/income-transactions/[id]/route.test.ts
+++ b/src/app/api/income-transactions/[id]/route.test.ts
@@ -6,6 +6,14 @@ vi.mock('next/headers', () => ({
   headers: vi.fn(() => Promise.resolve(new Headers())),
 }));
 
+vi.mock('next/server', async (importActual) => {
+  const mod = await importActual<typeof import('next/server')>();
+  return {
+    ...mod,
+    after: (cb: () => unknown) => { void cb(); },
+  };
+});
+
 vi.mock('@/lib/auth', () => ({
   auth: {
     api: {

--- a/src/app/api/income-transactions/[id]/route.ts
+++ b/src/app/api/income-transactions/[id]/route.ts
@@ -2,6 +2,7 @@ import { auth } from "@/lib/auth";
 import { db } from "@/lib/prisma";
 import { onIncomeTransactionChange } from "@/lib/statement-recalculator";
 import { headers } from "next/headers";
+import { after } from "next/server";
 import { NextRequest, NextResponse } from "next/server";
 import { PrismaPromise } from "@prisma/client";
 import { z } from "zod";
@@ -232,8 +233,19 @@ export async function PATCH(
     const results = await db.$transaction(operations);
     const result = results[results.length - 1] as { accountId: string; date: Date };
 
-    await onIncomeTransactionChange(existingTransaction.accountId, existingTransaction.date);
-    await onIncomeTransactionChange(result.accountId, result.date);
+    const oldAccountId = existingTransaction.accountId;
+    const oldDate = existingTransaction.date;
+    const newAccountId = result.accountId;
+    const newDate = result.date;
+
+    after(async () => {
+      try {
+        await onIncomeTransactionChange(oldAccountId, oldDate);
+        await onIncomeTransactionChange(newAccountId, newDate);
+      } catch (err) {
+        console.error('Error in deferred onIncomeTransactionChange (PATCH income):', err);
+      }
+    });
 
     return NextResponse.json(result, { status: 200 });
 
@@ -301,10 +313,16 @@ export async function DELETE(
       }),
     ]);
 
-    await onIncomeTransactionChange(
-      existingTransaction.accountId,
-      existingTransaction.date
-    );
+    const deletedAccountId = existingTransaction.accountId;
+    const deletedDate = existingTransaction.date;
+
+    after(async () => {
+      try {
+        await onIncomeTransactionChange(deletedAccountId, deletedDate);
+      } catch (err) {
+        console.error('Error in deferred onIncomeTransactionChange (DELETE income):', err);
+      }
+    });
 
     return NextResponse.json(
       { message: 'Income transaction deleted successfully' },

--- a/src/app/api/income-transactions/route.test.ts
+++ b/src/app/api/income-transactions/route.test.ts
@@ -6,6 +6,14 @@ vi.mock('next/headers', () => ({
   headers: vi.fn(() => Promise.resolve(new Headers())),
 }));
 
+vi.mock('next/server', async (importActual) => {
+  const mod = await importActual<typeof import('next/server')>();
+  return {
+    ...mod,
+    after: (cb: () => unknown) => { void cb(); },
+  };
+});
+
 vi.mock('@/lib/auth', () => ({
   auth: {
     api: {

--- a/src/app/api/income-transactions/route.ts
+++ b/src/app/api/income-transactions/route.ts
@@ -1,5 +1,6 @@
 import { auth } from "@/lib/auth";
 import { headers } from "next/headers";
+import { after } from "next/server";
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/prisma";
 import { Prisma, PrismaPromise } from "@prisma/client";
@@ -118,29 +119,30 @@ export async function GET(request: NextRequest) {
       whereClause.accountId = accountId;
     }
 
-    const total = await db.incomeTransaction.count({
-      where: whereClause,
-    });
-
     // Determine limit - if searching, return more results (up to 100)
     let effectiveTake = takeNumber;
     if (search && search.trim().length > 0) {
       effectiveTake = 100;
     }
 
-    const incomeTransactions = await db.incomeTransaction.findMany({
-      where: whereClause,
-      include: {
-        account: true,
-        incomeType: true,
-        tags: true,
-      },
-      orderBy: {
-        date: 'desc',
-      },
-      ...(skipNumber !== undefined && { skip: skipNumber }),
-      ...(effectiveTake !== undefined && { take: effectiveTake }),
-    });
+    const [total, incomeTransactions] = await Promise.all([
+      db.incomeTransaction.count({
+        where: whereClause,
+      }),
+      db.incomeTransaction.findMany({
+        where: whereClause,
+        include: {
+          account: true,
+          incomeType: true,
+          tags: true,
+        },
+        orderBy: {
+          date: 'desc',
+        },
+        ...(skipNumber !== undefined && { skip: skipNumber }),
+        ...(effectiveTake !== undefined && { take: effectiveTake }),
+      }),
+    ]);
 
     // Calculate hasMore
     const currentCount = (skipNumber || 0) + incomeTransactions.length;
@@ -220,8 +222,17 @@ export async function POST(request: NextRequest) {
 
     const results = await db.$transaction(operations);
     const result = results[results.length - 1];
+    const accountResult = results[0] as { accountType?: string } | undefined;
+    const accountType = accountResult?.accountType;
+    const txDate = new Date(date);
 
-    await onIncomeTransactionChange(accountId, new Date(date));
+    after(async () => {
+      try {
+        await onIncomeTransactionChange(accountId, txDate, undefined, accountType);
+      } catch (err) {
+        console.error('Error in deferred onIncomeTransactionChange (POST income):', err);
+      }
+    });
 
     return NextResponse.json(result, { status: 201 });
 

--- a/src/app/api/installments/[id]/route.test.ts
+++ b/src/app/api/installments/[id]/route.test.ts
@@ -7,6 +7,14 @@ vi.mock('next/headers', () => ({
   headers: vi.fn(() => Promise.resolve(new Headers())),
 }));
 
+vi.mock('next/server', async (importActual) => {
+  const mod = await importActual<typeof import('next/server')>();
+  return {
+    ...mod,
+    after: (cb: () => unknown) => { void cb(); },
+  };
+});
+
 vi.mock('@/lib/auth', () => ({
   auth: {
     api: {
@@ -273,6 +281,9 @@ describe('PATCH /api/installments/[id]', () => {
     vi.mocked(db.$transaction).mockResolvedValue([updatedRow] as any);
 
     await PATCH(makePatchRequest({ name: 'Updated Name' }), makeParams());
+    // Flush microtasks so the deferred after() callback fully resolves
+    await Promise.resolve();
+    await Promise.resolve();
 
     expect(onExpenseTransactionChange).toHaveBeenCalled();
   });
@@ -343,6 +354,9 @@ describe('DELETE /api/installments/[id]', () => {
     vi.mocked(db.$transaction).mockResolvedValue([{}, {}, {}] as any);
 
     await DELETE(makeDeleteRequest(), makeParams());
+    // Flush microtasks so the deferred after() callback fully resolves
+    await Promise.resolve();
+    await Promise.resolve();
 
     expect(onExpenseTransactionChange).toHaveBeenCalledWith('acc-1', mockInstallment.date);
   });

--- a/src/app/api/installments/[id]/route.ts
+++ b/src/app/api/installments/[id]/route.ts
@@ -2,6 +2,7 @@ import { auth } from "@/lib/auth";
 import { db } from "@/lib/prisma";
 import { onExpenseTransactionChange } from "@/lib/statement-recalculator";
 import { headers } from "next/headers";
+import { after } from "next/server";
 import { NextRequest, NextResponse } from "next/server";
 import { PrismaPromise } from "@prisma/client";
 import { z } from "zod";
@@ -209,10 +210,20 @@ export async function PATCH(
     const results = await db.$transaction(operations);
     const updated = results[results.length - 1];
 
-    await onExpenseTransactionChange(existing.accountId, oldStartForRecalc);
-    if (startDateChanged && newStartForRecalc) {
-      await onExpenseTransactionChange(existing.accountId, newStartForRecalc);
-    }
+    const installmentAccountId = existing.accountId;
+    const recalcOldDate = oldStartForRecalc;
+    const recalcNewDate = startDateChanged ? newStartForRecalc : undefined;
+
+    after(async () => {
+      try {
+        await onExpenseTransactionChange(installmentAccountId, recalcOldDate);
+        if (recalcNewDate) {
+          await onExpenseTransactionChange(installmentAccountId, recalcNewDate);
+        }
+      } catch (err) {
+        console.error('Error in deferred onExpenseTransactionChange (PATCH installment):', err);
+      }
+    });
 
     return NextResponse.json(updated, { status: 200 });
   } catch (error) {
@@ -281,7 +292,16 @@ export async function DELETE(
 
     await db.$transaction(operations);
 
-    await onExpenseTransactionChange(existing.accountId, existing.date);
+    const installmentAccountId = existing.accountId;
+    const installmentDate = existing.date;
+
+    after(async () => {
+      try {
+        await onExpenseTransactionChange(installmentAccountId, installmentDate);
+      } catch (err) {
+        console.error('Error in deferred onExpenseTransactionChange (DELETE installment):', err);
+      }
+    });
 
     return NextResponse.json(
       { message: 'Installment deleted successfully', deleted: true },

--- a/src/app/api/transactions/recent/route.ts
+++ b/src/app/api/transactions/recent/route.ts
@@ -34,39 +34,39 @@ export async function GET() {
 
     const userId = session.user.id;
 
-    const expenses = await db.expenseTransaction.findMany({
-      where: { 
-        userId,
-        isInstallment: false,
-      },
-      include: {
-        account: true,
-        expenseType: true,
-      },
-      orderBy: { date: 'desc' },
-      take: 6,
-    });
-
-    const incomes = await db.incomeTransaction.findMany({
-      where: { userId },
-      include: {
-        account: true,
-        incomeType: true,
-      },
-      orderBy: { date: 'desc' },
-      take: 6,
-    });
-
-    const transfers = await db.transferTransaction.findMany({
-      where: { userId },
-      include: {
-        fromAccount: true,
-        toAccount: true,
-        transferType: true,
-      },
-      orderBy: { date: 'desc' },
-      take: 6,
-    });
+    const [expenses, incomes, transfers] = await Promise.all([
+      db.expenseTransaction.findMany({
+        where: {
+          userId,
+          isInstallment: false,
+        },
+        include: {
+          account: true,
+          expenseType: true,
+        },
+        orderBy: { date: 'desc' },
+        take: 6,
+      }),
+      db.incomeTransaction.findMany({
+        where: { userId },
+        include: {
+          account: true,
+          incomeType: true,
+        },
+        orderBy: { date: 'desc' },
+        take: 6,
+      }),
+      db.transferTransaction.findMany({
+        where: { userId },
+        include: {
+          fromAccount: true,
+          toAccount: true,
+          transferType: true,
+        },
+        orderBy: { date: 'desc' },
+        take: 6,
+      }),
+    ]);
 
     const expenseTransactions: RecentTransaction[] = expenses.map((exp) => ({
       id: exp.id,

--- a/src/app/api/transfer-transactions/[id]/route.test.ts
+++ b/src/app/api/transfer-transactions/[id]/route.test.ts
@@ -6,6 +6,14 @@ vi.mock('next/headers', () => ({
   headers: vi.fn(() => Promise.resolve(new Headers())),
 }));
 
+vi.mock('next/server', async (importActual) => {
+  const mod = await importActual<typeof import('next/server')>();
+  return {
+    ...mod,
+    after: (cb: () => unknown) => { void cb(); },
+  };
+});
+
 vi.mock('@/lib/auth', () => ({
   auth: {
     api: {

--- a/src/app/api/transfer-transactions/[id]/route.ts
+++ b/src/app/api/transfer-transactions/[id]/route.ts
@@ -2,6 +2,7 @@ import { auth } from "@/lib/auth";
 import { db } from "@/lib/prisma";
 import { onTransferTransactionChange } from "@/lib/statement-recalculator";
 import { headers } from "next/headers";
+import { after } from "next/server";
 import { NextRequest, NextResponse } from "next/server";
 import { PrismaPromise } from "@prisma/client";
 import { randomUUID } from "crypto";
@@ -355,8 +356,23 @@ export async function PATCH(
     const results = await db.$transaction(operations);
     const result = results[results.length - 1] as { fromAccountId: string; toAccountId: string; transferTypeId: string; date: Date };
 
-    await onTransferTransactionChange(existingTransfer.fromAccountId, existingTransfer.toAccountId, existingTransfer.transferTypeId, existingTransfer.date);
-    await onTransferTransactionChange(result.fromAccountId, result.toAccountId, result.transferTypeId, result.date);
+    const oldFromAccountId = existingTransfer.fromAccountId;
+    const oldToAccountId = existingTransfer.toAccountId;
+    const oldTransferTypeId = existingTransfer.transferTypeId;
+    const oldDate = existingTransfer.date;
+    const newFromAccountId = result.fromAccountId;
+    const newToAccountId = result.toAccountId;
+    const newTransferTypeId = result.transferTypeId;
+    const newDate = result.date;
+
+    after(async () => {
+      try {
+        await onTransferTransactionChange(oldFromAccountId, oldToAccountId, oldTransferTypeId, oldDate);
+        await onTransferTransactionChange(newFromAccountId, newToAccountId, newTransferTypeId, newDate);
+      } catch (err) {
+        console.error('Error in deferred onTransferTransactionChange (PATCH transfer):', err);
+      }
+    });
 
     return NextResponse.json(results[results.length - 1], { status: 200 });
   } catch (error) {
@@ -447,7 +463,15 @@ export async function DELETE(
 
     await db.$transaction(operations);
 
-    await onTransferTransactionChange(existingTransfer.fromAccountId, existingTransfer.toAccountId, existingTransfer.transferTypeId, existingTransfer.date);
+    const { fromAccountId: delFromId, toAccountId: delToId, transferTypeId: delTypeId, date: delDate } = existingTransfer;
+
+    after(async () => {
+      try {
+        await onTransferTransactionChange(delFromId, delToId, delTypeId, delDate);
+      } catch (err) {
+        console.error('Error in deferred onTransferTransactionChange (DELETE transfer):', err);
+      }
+    });
 
     return NextResponse.json(
       { message: 'Transfer transaction deleted successfully' },

--- a/src/app/api/transfer-transactions/route.test.ts
+++ b/src/app/api/transfer-transactions/route.test.ts
@@ -6,6 +6,14 @@ vi.mock('next/headers', () => ({
   headers: vi.fn(() => Promise.resolve(new Headers())),
 }));
 
+vi.mock('next/server', async (importActual) => {
+  const mod = await importActual<typeof import('next/server')>();
+  return {
+    ...mod,
+    after: (cb: () => unknown) => { void cb(); },
+  };
+});
+
 vi.mock('@/lib/auth', () => ({
   auth: {
     api: {

--- a/src/app/api/transfer-transactions/route.ts
+++ b/src/app/api/transfer-transactions/route.ts
@@ -1,5 +1,6 @@
 import { auth } from "@/lib/auth";
 import { headers } from "next/headers";
+import { after } from "next/server";
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/prisma";
 import { Prisma, PrismaPromise } from "@prisma/client";
@@ -139,30 +140,30 @@ export async function GET(request: NextRequest) {
       ];
     }
 
-    const total = await db.transferTransaction.count({
-      where: whereClause,
-    });
-
     let effectiveTake = takeNumber;
     if (search && search.trim().length > 0) {
       effectiveTake = 100;
     }
 
-    // Get transactions with optional pagination
-    const transferTransactions = await db.transferTransaction.findMany({
-      where: whereClause,
-      include: {
-        fromAccount: true,
-        toAccount: true,
-        transferType: true,
-        tags: true,
-      },
-      orderBy: {
-        date: 'desc'
-      },
-      ...(skipNumber !== undefined && { skip: skipNumber }),
-      ...(effectiveTake !== undefined && { take: effectiveTake }),
-    });
+    const [total, transferTransactions] = await Promise.all([
+      db.transferTransaction.count({
+        where: whereClause,
+      }),
+      db.transferTransaction.findMany({
+        where: whereClause,
+        include: {
+          fromAccount: true,
+          toAccount: true,
+          transferType: true,
+          tags: true,
+        },
+        orderBy: {
+          date: 'desc'
+        },
+        ...(skipNumber !== undefined && { skip: skipNumber }),
+        ...(effectiveTake !== undefined && { take: effectiveTake }),
+      }),
+    ]);
 
     // Calculate hasMore
     const currentCount = (skipNumber || 0) + transferTransactions.length;
@@ -307,8 +308,23 @@ export async function POST(request: NextRequest) {
 
     const results = await db.$transaction(operations);
     const result = results[transferIndex] as { fromAccountId: string; toAccountId: string; transferTypeId: string; date: Date };
+    const fromAccountResult = results[transferIndex + 1] as { accountType?: string } | undefined;
+    const toAccountResult = results[transferIndex + 2] as { accountType?: string } | undefined;
 
-    await onTransferTransactionChange(result.fromAccountId, result.toAccountId, result.transferTypeId, result.date);
+    const txFromAccountId = result.fromAccountId;
+    const txToAccountId = result.toAccountId;
+    const txTransferTypeId = result.transferTypeId;
+    const txDate = result.date;
+    const fromAccountType = fromAccountResult?.accountType;
+    const toAccountType = toAccountResult?.accountType;
+
+    after(async () => {
+      try {
+        await onTransferTransactionChange(txFromAccountId, txToAccountId, txTransferTypeId, txDate, undefined, fromAccountType, toAccountType);
+      } catch (err) {
+        console.error('Error in deferred onTransferTransactionChange (POST transfer):', err);
+      }
+    });
 
     return NextResponse.json(results[transferIndex], { status: 201 });
 

--- a/src/lib/statement-recalculator.test.ts
+++ b/src/lib/statement-recalculator.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/prisma', () => ({
+  db: {
+    financialAccount: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+    transferType: {
+      findUnique: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('@/lib/statement-calculator', () => ({
+  calculateStatementBalance: vi.fn().mockResolvedValue(100),
+}));
+
+import { db } from '@/lib/prisma';
+import { onIncomeTransactionChange, onExpenseTransactionChange } from './statement-recalculator';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('accountType hint — non-CREDIT_CARD short-circuit', () => {
+  it('skips findUnique when accountType hint is SAVINGS', async () => {
+    await onIncomeTransactionChange('acc-1', new Date('2026-01-15'), undefined, 'SAVINGS');
+
+    expect(db.financialAccount.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('skips findUnique when accountType hint is CASH', async () => {
+    await onExpenseTransactionChange('acc-2', new Date('2026-01-15'), undefined, 'CASH');
+
+    expect(db.financialAccount.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('still queries findUnique when no accountType hint is provided', async () => {
+    vi.mocked(db.financialAccount.findUnique).mockResolvedValue(null);
+
+    await onIncomeTransactionChange('acc-3', new Date('2026-01-15'));
+
+    expect(db.financialAccount.findUnique).toHaveBeenCalledOnce();
+  });
+
+  it('still queries findUnique when accountType hint is CREDIT_CARD', async () => {
+    vi.mocked(db.financialAccount.findUnique).mockResolvedValue(null);
+
+    await onExpenseTransactionChange('acc-4', new Date('2026-01-15'), undefined, 'CREDIT_CARD');
+
+    expect(db.financialAccount.findUnique).toHaveBeenCalledOnce();
+  });
+});

--- a/src/lib/statement-recalculator.ts
+++ b/src/lib/statement-recalculator.ts
@@ -12,8 +12,18 @@ import { calculateStatementBalance } from "@/lib/statement-calculator";
  *
  * @param cardId - The FinancialAccount id of the credit card
  * @param transactionDate - The date of the transaction being created/edited/deleted
+ * @param accountType - Optional hint: if provided and not CREDIT_CARD, skip the DB lookup
  */
-async function recalculateForCard(cardId: string, transactionDate: Date): Promise<void> {
+async function recalculateForCard(
+  cardId: string,
+  transactionDate: Date,
+  accountType?: string
+): Promise<void> {
+  // Short-circuit: if we know the account is not a credit card, skip entirely
+  if (accountType !== undefined && accountType !== "CREDIT_CARD") {
+    return;
+  }
+
   const card = await db.financialAccount.findUnique({
     where: {
       id: cardId,
@@ -45,8 +55,6 @@ async function recalculateForCard(cardId: string, transactionDate: Date): Promis
     return;
   }
 
-  console.log(`Recalculating statement balance for card "${card.name}" (${card.id}), cycle: ${cycleStart.toISOString()} → ${cycleEnd.toISOString()}`);
-
   const previousBalance = Number(card.previousStatementBalance ?? 0);
   const newBalance = await calculateStatementBalance(card.id, cycleStart, cycleEnd, previousBalance);
 
@@ -54,8 +62,6 @@ async function recalculateForCard(cardId: string, transactionDate: Date): Promis
     where: { id: card.id },
     data: { statementBalance: newBalance },
   });
-
-  console.log(`Statement balance updated to ${newBalance} for card "${card.name}" (${card.id})`);
 }
 
 /**
@@ -65,17 +71,19 @@ async function recalculateForCard(cardId: string, transactionDate: Date): Promis
  * @param accountId - The card the expense is on
  * @param transactionDate - The date of the expense
  * @param oldDate - (edit only) The previous date, if the date was changed
+ * @param accountType - Optional hint: if not CREDIT_CARD, skips the DB lookup
  */
 export async function onExpenseTransactionChange(
   accountId: string,
   transactionDate: Date,
-  oldDate?: Date
+  oldDate?: Date,
+  accountType?: string
 ): Promise<void> {
-  await recalculateForCard(accountId, transactionDate);
+  await recalculateForCard(accountId, transactionDate, accountType);
 
   // If the date changed, also check the old date's cycle
   if (oldDate && new Date(oldDate).getTime() !== new Date(transactionDate).getTime()) {
-    await recalculateForCard(accountId, oldDate);
+    await recalculateForCard(accountId, oldDate, accountType);
   }
 }
 
@@ -90,13 +98,17 @@ export async function onExpenseTransactionChange(
  * @param transferTypeId - The TransferType id
  * @param transactionDate - The date of the transfer
  * @param oldDate - (edit only) The previous date, if the date was changed
+ * @param fromAccountType - Optional hint for the from account type
+ * @param toAccountType - Optional hint for the to account type
  */
 export async function onTransferTransactionChange(
   fromAccountId: string,
   toAccountId: string,
   transferTypeId: string,
   transactionDate: Date,
-  oldDate?: Date
+  oldDate?: Date,
+  fromAccountType?: string,
+  toAccountType?: string
 ): Promise<void> {
   const transferType = await db.transferType.findUnique({
     where: { id: transferTypeId },
@@ -105,16 +117,16 @@ export async function onTransferTransactionChange(
   if (!transferType) return;
 
   if (transferType.name === "Credit Card Payment") {
-    await recalculateForCard(toAccountId, transactionDate);
+    await recalculateForCard(toAccountId, transactionDate, toAccountType);
 
     if (oldDate && new Date(oldDate).getTime() !== new Date(transactionDate).getTime()) {
-      await recalculateForCard(toAccountId, oldDate);
+      await recalculateForCard(toAccountId, oldDate, toAccountType);
     }
   } else {
-    await recalculateForCard(fromAccountId, transactionDate);
+    await recalculateForCard(fromAccountId, transactionDate, fromAccountType);
 
     if (oldDate && new Date(oldDate).getTime() !== new Date(transactionDate).getTime()) {
-      await recalculateForCard(fromAccountId, oldDate);
+      await recalculateForCard(fromAccountId, oldDate, fromAccountType);
     }
   }
 }
@@ -126,15 +138,17 @@ export async function onTransferTransactionChange(
  * @param accountId - The card the income is on
  * @param transactionDate - The date of the income
  * @param oldDate - (edit only) The previous date, if the date was changed
+ * @param accountType - Optional hint: if not CREDIT_CARD, skips the DB lookup
  */
 export async function onIncomeTransactionChange(
   accountId: string,
   transactionDate: Date,
-  oldDate?: Date
+  oldDate?: Date,
+  accountType?: string
 ): Promise<void> {
-  await recalculateForCard(accountId, transactionDate);
+  await recalculateForCard(accountId, transactionDate, accountType);
 
   if (oldDate && new Date(oldDate).getTime() !== new Date(transactionDate).getTime()) {
-    await recalculateForCard(accountId, oldDate);
+    await recalculateForCard(accountId, oldDate, accountType);
   }
 }


### PR DESCRIPTION
Phase 1 of the Performance & UI Polish effort (see docs/perf-and-ui-polish-spec.md).

- Move statement recalculation off the response path using Next 15 `after()` in all expense/income/transfer routes (POST + [id] PATCH/DELETE) plus installments/[id]. Each `after()` body wrapped in try/catch + console.error so a deferred recalc failure is logged rather than silent.
- Skip the recalculator's findUnique for non-credit-card accounts via an optional accountType hint; findUnique fallback retained for hint-less paths.
- Parallelize independent queries with Promise.all in transactions/recent and the count+findMany pairs in expense/income list GETs.
- Remove two console.log calls from the recalculator.

Tests, lint, and build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)