### PR TITLE
refactor(net-worth): aggregate history in SQL instead of fetching all rows

### DIFF
--- a/src/app/api/net-worth/history/route.test.ts
+++ b/src/app/api/net-worth/history/route.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { computeCumulativeNetWorth } from '@/lib/net-worth-history';
+
+describe('computeCumulativeNetWorth', () => {
+  const window12 = [
+    { year: 2024, month: 7 },
+    { year: 2024, month: 8 },
+    { year: 2024, month: 9 },
+    { year: 2024, month: 10 },
+    { year: 2024, month: 11 },
+    { year: 2024, month: 12 },
+    { year: 2025, month: 1 },
+    { year: 2025, month: 2 },
+    { year: 2025, month: 3 },
+    { year: 2025, month: 4 },
+    { year: 2025, month: 5 },
+    { year: 2025, month: 6 },
+  ];
+
+  it('returns an empty array when windowMonths is empty', () => {
+    const result = computeCumulativeNetWorth(1000, [], [], []);
+    expect(result).toEqual([]);
+  });
+
+  it('returns initialBalance for every month when there are no transactions', () => {
+    const result = computeCumulativeNetWorth(5000, [], [], window12);
+    expect(result).toHaveLength(12);
+    for (const entry of result) {
+      expect(entry.netWorth).toBe(5000);
+    }
+  });
+
+  it('accumulates income and expenses correctly across months', () => {
+    const incomeRows = [
+      { year: 2024, month: 7, total: 1000 },
+      { year: 2024, month: 8, total: 2000 },
+    ];
+    const expenseRows = [
+      { year: 2024, month: 7, total: 500 },
+      { year: 2024, month: 9, total: 300 },
+    ];
+
+    const result = computeCumulativeNetWorth(0, incomeRows, expenseRows, window12);
+
+    // July 2024: 0 + 1000 - 500 = 500
+    expect(result[0].netWorth).toBe(500);
+    // Aug 2024: 0 + (1000+2000) - 500 = 2500
+    expect(result[1].netWorth).toBe(2500);
+    // Sep 2024: 0 + 3000 - (500+300) = 2200
+    expect(result[2].netWorth).toBe(2200);
+    // Oct..Dec should be same as Sep (no new rows)
+    expect(result[3].netWorth).toBe(2200);
+  });
+
+  it('includes rows from before the window in cumulative sum', () => {
+    // Row from 2023 is before the window but must still be included
+    const incomeRows = [{ year: 2023, month: 1, total: 10000 }];
+    const result = computeCumulativeNetWorth(0, incomeRows, [], [{ year: 2025, month: 1 }]);
+    expect(result[0].netWorth).toBe(10000);
+  });
+
+  it('rounds to 2 decimal places', () => {
+    const incomeRows = [{ year: 2025, month: 1, total: 0.1 }];
+    const expenseRows = [{ year: 2025, month: 1, total: 0.2 }];
+    const result = computeCumulativeNetWorth(0, incomeRows, expenseRows, [{ year: 2025, month: 1 }]);
+    expect(result[0].netWorth).toBe(Math.round((0.1 - 0.2) * 100) / 100);
+  });
+
+  it('produces correct month labels', () => {
+    const result = computeCumulativeNetWorth(0, [], [], [{ year: 2025, month: 6 }]);
+    expect(result[0].month).toBe('Jun 2025');
+  });
+});

--- a/src/app/api/net-worth/history/route.ts
+++ b/src/app/api/net-worth/history/route.ts
@@ -2,8 +2,15 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { headers } from "next/headers";
 import { db } from "@/lib/prisma";
+import { computeCumulativeNetWorth } from "@/lib/net-worth-history";
 
 export const dynamic = 'force-dynamic';
+
+interface MonthlyAggregate {
+  year: number;
+  month: number;
+  total: number;
+}
 
 export async function GET(_req: NextRequest) {
   try {
@@ -44,64 +51,49 @@ export async function GET(_req: NextRequest) {
       0
     );
 
-    // Bulk fetch ALL transactions
-    const [incomeTransactions, expenseTransactions] = await Promise.all([
-      db.incomeTransaction.findMany({
-        where: {
-          userId,
-          accountId: { in: accountIds }
-        },
-        select: {
-          amount: true,
-          date: true,
-        }
-      }),
-      db.expenseTransaction.findMany({
-        where: {
-          userId,
-          accountId: { in: accountIds },
-          isInstallment: false,
-        },
-        select: {
-          amount: true,
-          date: true,
-        }
-      }),
+    // Aggregate monthly income and expenses via SQL GROUP BY (no unbounded row scan in JS)
+    const [incomeRows, expenseRows] = await Promise.all([
+      db.$queryRaw<MonthlyAggregate[]>`
+        SELECT
+          EXTRACT(YEAR FROM date)::int  AS year,
+          EXTRACT(MONTH FROM date)::int AS month,
+          SUM(amount)::float            AS total
+        FROM income_transactions
+        WHERE user_id = ${userId}
+          AND account_id = ANY(${accountIds}::uuid[])
+        GROUP BY year, month
+        ORDER BY year ASC, month ASC
+      `,
+      db.$queryRaw<MonthlyAggregate[]>`
+        SELECT
+          EXTRACT(YEAR FROM date)::int  AS year,
+          EXTRACT(MONTH FROM date)::int AS month,
+          SUM(amount)::float            AS total
+        FROM expense_transactions
+        WHERE user_id = ${userId}
+          AND account_id = ANY(${accountIds}::uuid[])
+          AND is_installment = false
+        GROUP BY year, month
+        ORDER BY year ASC, month ASC
+      `,
     ]);
 
-    const months: { month: string; netWorth: number }[] = [];
+    // Build the trailing-12-months window (oldest first)
     const now = new Date();
-
-    // Calculate net worth for each of the last 12 months
+    const windowMonths: { year: number; month: number }[] = [];
     for (let i = 11; i >= 0; i--) {
-      const targetDate = new Date(now.getFullYear(), now.getMonth() - i, 1);
-      const endOfMonth = new Date(targetDate.getFullYear(), targetDate.getMonth() + 1, 0, 23, 59, 59, 999);
-      
-      // Filter and sum income up to end of this month
-      const totalIncome = incomeTransactions
-        .filter(t => new Date(t.date) <= endOfMonth)
-        .reduce((sum, t) => sum + parseFloat(t.amount.toString()), 0);
-
-      // Filter and sum expenses up to end of this month
-      const totalExpenses = expenseTransactions
-        .filter(t => new Date(t.date) <= endOfMonth)
-        .reduce((sum, t) => sum + parseFloat(t.amount.toString()), 0);
-
-      // Net worth = initial balance + income - expenses
-      const netWorth = totalInitialBalance + totalIncome - totalExpenses;
-
-      const monthLabel = targetDate.toLocaleDateString('en-US', { 
-        month: 'short', 
-        year: 'numeric' 
-      });
-
-      months.push({
-        month: monthLabel,
-        netWorth: Math.round(netWorth * 100) / 100
-      });
+      const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
+      windowMonths.push({ year: d.getFullYear(), month: d.getMonth() + 1 });
     }
 
-    return NextResponse.json({ history: months });
+    const history = computeCumulativeNetWorth(
+      totalInitialBalance,
+      incomeRows,
+      expenseRows,
+      windowMonths
+    );
+
+    return NextResponse.json({ history });
 
   } catch (error) {
     console.error("Error fetching net worth history:", error);

--- a/src/lib/net-worth-history.ts
+++ b/src/lib/net-worth-history.ts
@@ -1,0 +1,55 @@
+interface MonthlyAggregate {
+  year: number;
+  month: number;
+  total: number;
+}
+
+/**
+ * Computes trailing-12-months cumulative net worth from monthly aggregates.
+ *
+ * @param totalInitialBalance - Sum of initialBalance across all net-worth accounts
+ * @param incomeRows - Monthly income aggregates (all time, for accounts in scope)
+ * @param expenseRows - Monthly expense aggregates (all time, for accounts in scope)
+ * @param windowMonths - Array of { year, month } for the 12-month window (oldest first)
+ * @returns Array of { month: string, netWorth: number } in the same order
+ */
+export function computeCumulativeNetWorth(
+  totalInitialBalance: number,
+  incomeRows: MonthlyAggregate[],
+  expenseRows: MonthlyAggregate[],
+  windowMonths: { year: number; month: number }[]
+): { month: string; netWorth: number }[] {
+  const result: { month: string; netWorth: number }[] = [];
+
+  for (const { year, month } of windowMonths) {
+    // Sum all rows up to and including this month
+    let totalIncome = 0;
+    for (const row of incomeRows) {
+      if (row.year < year || (row.year === year && row.month <= month)) {
+        totalIncome += row.total;
+      }
+    }
+
+    let totalExpenses = 0;
+    for (const row of expenseRows) {
+      if (row.year < year || (row.year === year && row.month <= month)) {
+        totalExpenses += row.total;
+      }
+    }
+
+    const netWorth = totalInitialBalance + totalIncome - totalExpenses;
+
+    const date = new Date(year, month - 1, 1);
+    const monthLabel = date.toLocaleDateString('en-US', {
+      month: 'short',
+      year: 'numeric',
+    });
+
+    result.push({
+      month: monthLabel,
+      netWorth: Math.round(netWorth * 100) / 100,
+    });
+  }
+
+  return result;
+}


### PR DESCRIPTION
Phase 4 of the Performance & UI Polish effort (see docs/perf-and-ui-polish-spec.md).

- Replace the two unbounded findMany calls in net-worth/history with two $queryRaw monthly GROUP BY aggregates (copying the annual-summary pattern), then compute the trailing-12-month cumulative series in JS from ~tens of rows.
- Response shape `{ history: [{ month, netWorth }] }` is byte-identical. Still fully recompute-on-read — no caching.
- New pure `computeCumulativeNetWorth` in src/lib/net-worth-history.ts with 6 unit tests.

Tests, lint, and build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)