### PR TITLE
chore(hygiene): remove console noise, drop jsdom, enforce search min-length

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,6 @@
         "eslint": "^9",
         "eslint-config-next": "15.3.5",
         "happy-dom": "^20.8.4",
-        "jsdom": "^28.1.0",
         "tailwindcss": "^4.1.11",
         "tw-animate-css": "^1.3.5",
         "typescript": "^5",
@@ -76,7 +75,9 @@
       "version": "0.9.31",
       "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
       "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -108,6 +109,8 @@
       "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.0.1.tgz",
       "integrity": "sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@csstools/css-calc": "^3.1.1",
         "@csstools/css-color-parser": "^4.0.2",
@@ -124,6 +127,8 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
       "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": "20 || >=22"
       }
@@ -133,6 +138,8 @@
       "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
       "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@asamuzakjp/nwsapi": "^2.3.9",
         "bidi-js": "^1.0.3",
@@ -146,6 +153,8 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
       "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": "20 || >=22"
       }
@@ -154,7 +163,9 @@
       "version": "2.3.9",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -206,6 +217,8 @@
       "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
       "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "css-tree": "^3.0.0"
       },
@@ -228,6 +241,8 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -247,6 +262,8 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -270,6 +287,8 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@csstools/color-helpers": "^6.0.2",
         "@csstools/css-calc": "^3.1.1"
@@ -297,6 +316,8 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -318,7 +339,9 @@
           "type": "opencollective",
           "url": "https://opencollective.com/csstools"
         }
-      ]
+      ],
+      "optional": true,
+      "peer": true
     },
     "node_modules/@csstools/css-tokenizer": {
       "version": "4.0.0",
@@ -335,6 +358,8 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -510,6 +535,8 @@
       "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.14.1.tgz",
       "integrity": "sha512-OhkBFWI6GcRMUroChZiopRiSp2iAMvEBK47NhJooDqz1RERO4QuZIZnjP63TXX8GAiLABkYmX+fuQsdJ1dd2QQ==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
@@ -4746,6 +4773,8 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 14"
       }
@@ -5087,6 +5116,8 @@
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
       "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "require-from-string": "^2.0.2"
       }
@@ -5374,6 +5405,8 @@
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
       "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "mdn-data": "2.12.2",
         "source-map-js": "^1.0.1"
@@ -5387,6 +5420,8 @@
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.1.0.tgz",
       "integrity": "sha512-Ml4fP2UT2K3CUBQnVlbdV/8aFDdlY69E+YnwJM+3VUWl08S3J8c8aRuJqCkD9Py8DHZ7zNNvsfKl8psocHZEFg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.0.0",
         "@csstools/css-syntax-patches-for-csstree": "^1.0.28",
@@ -5402,6 +5437,8 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
       "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": "20 || >=22"
       }
@@ -5532,6 +5569,8 @@
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
       "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "whatwg-mimetype": "^5.0.0",
         "whatwg-url": "^16.0.0"
@@ -5626,7 +5665,9 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
@@ -5799,6 +5840,8 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -6932,6 +6975,8 @@
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
       "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@exodus/bytes": "^1.6.0"
       },
@@ -6944,6 +6989,8 @@
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.0",
         "debug": "^4.3.4"
@@ -6957,6 +7004,8 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "4"
@@ -7279,7 +7328,9 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/is-regex": {
       "version": "1.2.1",
@@ -7496,6 +7547,8 @@
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
       "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
         "@asamuzakjp/dom-selector": "^6.8.1",
@@ -7953,7 +8006,9 @@
       "version": "2.12.2",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
       "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -8489,6 +8544,8 @@
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
       "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "entities": "^6.0.0"
       },
@@ -9144,6 +9201,8 @@
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9325,6 +9384,8 @@
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "xmlchars": "^2.2.0"
       },
@@ -9826,7 +9887,9 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/tailwind-merge": {
       "version": "3.3.1",
@@ -9948,6 +10011,8 @@
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.23.tgz",
       "integrity": "sha512-ASdhgQIBSay0R/eXggAkQ53G4nTJqTXqC2kbaBbdDwM7SkjyZyO0OaaN1/FH7U/yCeqOHDwFO5j8+Os/IS1dXw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "tldts-core": "^7.0.23"
       },
@@ -9959,7 +10024,9 @@
       "version": "7.0.23",
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.23.tgz",
       "integrity": "sha512-0g9vrtDQLrNIiCj22HSe9d4mLVG3g5ph5DZ8zCKBr4OtrspmNB6ss7hVyzArAeE88ceZocIEGkyW1Ime7fxPtQ==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -9978,6 +10045,8 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
       "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "tldts": "^7.0.5"
       },
@@ -9990,6 +10059,8 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
       "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "punycode": "^2.3.1"
       },
@@ -10176,6 +10247,8 @@
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
       "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=20.18.1"
       }
@@ -11333,6 +11406,8 @@
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
       "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "xml-name-validator": "^5.0.0"
       },
@@ -11345,6 +11420,8 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
       "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=20"
       }
@@ -11354,6 +11431,8 @@
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
       "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=20"
       }
@@ -11363,6 +11442,8 @@
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
       "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@exodus/bytes": "^1.11.0",
         "tr46": "^6.0.0",
@@ -11523,6 +11604,8 @@
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
       "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11531,7 +11614,9 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/yallist": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "eslint": "^9",
     "eslint-config-next": "15.3.5",
     "happy-dom": "^20.8.4",
-    "jsdom": "^28.1.0",
     "tailwindcss": "^4.1.11",
     "tw-animate-css": "^1.3.5",
     "typescript": "^5",

--- a/src/app/expenses/page.tsx
+++ b/src/app/expenses/page.tsx
@@ -49,10 +49,12 @@ const Expenses = () => {
   const [editExpenseDrawerOpen, setEditExpenseDrawerOpen] = useState(false);
   const [selectedExpenseId, setSelectedExpenseId] = useState<string>('');
 
-  // Debounce effect - increased to 500ms to prevent triggering on slow backspace
+  // Debounce effect — 500ms delay, min 2 chars before firing (clears on empty)
   useEffect(() => {
     const timer = setTimeout(() => {
-      setDebouncedSearchTerm(searchTerm);
+      if (searchTerm.length === 0 || searchTerm.length >= 2) {
+        setDebouncedSearchTerm(searchTerm);
+      }
     }, 500);
     return () => clearTimeout(timer);
   }, [searchTerm]);

--- a/src/app/income/page.tsx
+++ b/src/app/income/page.tsx
@@ -74,9 +74,12 @@ const Income = () => {
   const [selectedIncomeTransactionId, setSelectedIncomeTransactionId] = useState<string>('');
   const [editIncomeTransactionDrawerOpen, setEditIncomeTransactionDrawerOpen] = useState(false);
 
+  // Debounce effect — 500ms delay, min 2 chars before firing (clears on empty)
   useEffect(() => {
     const timer = setTimeout(() => {
-      setDebouncedSearchTerm(searchTerm);
+      if (searchTerm.length === 0 || searchTerm.length >= 2) {
+        setDebouncedSearchTerm(searchTerm);
+      }
     }, 500);
     return () => clearTimeout(timer);
   }, [searchTerm]);

--- a/src/app/transfers/page.tsx
+++ b/src/app/transfers/page.tsx
@@ -39,9 +39,12 @@ const Transactions = () => {
   const [selectedTransferId, setSelectedTransferId] = useState<string>('');
   const [editTransferDrawerOpen, setEditTransferDrawerOpen] = useState(false);
 
+  // Debounce effect — 500ms delay, min 2 chars before firing (clears on empty)
   useEffect(() => {
     const timer = setTimeout(() => {
-      setDebouncedSearchTerm(searchTerm);
+      if (searchTerm.length === 0 || searchTerm.length >= 2) {
+        setDebouncedSearchTerm(searchTerm);
+      }
     }, 500);
     return () => clearTimeout(timer);
   }, [searchTerm]);

--- a/src/components/forms/CreateAccountDrawer.tsx
+++ b/src/components/forms/CreateAccountDrawer.tsx
@@ -42,9 +42,6 @@ const CreateAccountDrawer = ({ open, onOpenChange, className }: CreateAccountDra
     const checkScroll = () => {
       const scrollElement = scrollRef.current?.querySelector('[data-radix-scroll-area-viewport]');
       
-      console.log('🔍 [CreateCardDrawer] checkScroll called');
-      console.log('  - scrollElement exists:', !!scrollElement);
-      
       if (scrollElement) {
         const { scrollTop, scrollHeight, clientHeight } = scrollElement;
         const isScrollable = scrollHeight > clientHeight;
@@ -61,7 +58,6 @@ const CreateAccountDrawer = ({ open, onOpenChange, className }: CreateAccountDra
       
       if (scrollElement) {
         scrollElement.addEventListener('scroll', checkScroll);
-        console.log('✅ [CreateCardDrawer] Scroll listener added');
         checkScroll();
       }
     }, 100);

--- a/src/lib/statement-recalculator.ts
+++ b/src/lib/statement-recalculator.ts
@@ -45,8 +45,6 @@ async function recalculateForCard(cardId: string, transactionDate: Date): Promis
     return;
   }
 
-  console.log(`Recalculating statement balance for card "${card.name}" (${card.id}), cycle: ${cycleStart.toISOString()} → ${cycleEnd.toISOString()}`);
-
   const previousBalance = Number(card.previousStatementBalance ?? 0);
   const newBalance = await calculateStatementBalance(card.id, cycleStart, cycleEnd, previousBalance);
 
@@ -54,8 +52,6 @@ async function recalculateForCard(cardId: string, transactionDate: Date): Promis
     where: { id: card.id },
     data: { statementBalance: newBalance },
   });
-
-  console.log(`Statement balance updated to ${newBalance} for card "${card.name}" (${card.id})`);
 }
 
 /**


### PR DESCRIPTION
Phase 6 of the Performance & UI Polish effort (see docs/perf-and-ui-polish-spec.md).

- Remove 3 console.log calls from CreateAccountDrawer and 2 from statement-recalculator (console.error in catch blocks kept).
- Uninstall unused `jsdom` devDependency (config uses happy-dom).
- Add a minimum 2-character guard to the expense/income/transfer search debounce (already 500ms).

Tests, lint, and build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)