### PR TITLE
fix(net-worth): cast account ids to text[] not uuid[] in history SQL

### DIFF
--- a/src/app/api/net-worth/history/route.ts
+++ b/src/app/api/net-worth/history/route.ts
@@ -60,7 +60,7 @@ export async function GET(_req: NextRequest) {
           SUM(amount)::float            AS total
         FROM income_transactions
         WHERE user_id = ${userId}
-          AND account_id = ANY(${accountIds}::uuid[])
+          AND account_id = ANY(${accountIds}::text[])
         GROUP BY year, month
         ORDER BY year ASC, month ASC
       `,
@@ -71,7 +71,7 @@ export async function GET(_req: NextRequest) {
           SUM(amount)::float            AS total
         FROM expense_transactions
         WHERE user_id = ${userId}
-          AND account_id = ANY(${accountIds}::uuid[])
+          AND account_id = ANY(${accountIds}::text[])
           AND is_installment = false
         GROUP BY year, month
         ORDER BY year ASC, month ASC


### PR DESCRIPTION
The history aggregate queries cast account_id to ::uuid[], but ids are cuid strings on text columns (String @default(cuid()), no @db.Uuid), so Postgres raised "invalid input syntax for type uuid" and the route 500'd. Cast to ::text[] to match the column type.